### PR TITLE
Allow created user to have NOPASSWD sudo privileges

### DIFF
--- a/system_bootstrap/setup.sh
+++ b/system_bootstrap/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 main() {
-  echo "Welcome to Frank's ssytem bootstrap script!"
+  echo "Welcome to Frank's system bootstrap script!"
   echo "This script should be ran as root."
 
   installDependencies
@@ -33,9 +33,9 @@ setupUserAccount() {
     fi
   done
 
-  adduser "$username" sudo
+  echo "$username ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee "/etc/sudoers.d/dont-prompt-$username-for-sudo-password"
 
-  echo "🎉 Added sudo privilege for $username"
+  echo "🎉 Added sudo privilege for $username with NOPASSWD bypass"
   
   source_dir=$(dirname "$(dirname "$(realpath "$0")")")
   dest_dir="/home/$username/"

--- a/user_bootstrap/resources/update_all.sh
+++ b/user_bootstrap/resources/update_all.sh
@@ -8,7 +8,7 @@ successful_updates=0
 for file in "$update_scripts_dir"/*.sh; do
   if bash "$file"; then
     echo "Successfully executed $file."
-    successful_updates+=1
+    ((successful_updates+=1))
   else
     echo "Failed executing $file. Skipping."
   fi


### PR DESCRIPTION
Testing:
Created an update script with the following code:

```bash
#!/bin/bash

echo (sudo -l)
```

Then ran `setup.sh` and `update_all.sh` manually. Output printed permissions of the created user including the NOPASSWD property.